### PR TITLE
Add Bayesian neural network support

### DIFF
--- a/surrogate/NN_surrogate/models.py
+++ b/surrogate/NN_surrogate/models.py
@@ -50,6 +50,9 @@ def _create_arch(config):
     elif config.arch_name == "BatchNorm_Mlp":
         arch = archs.BatchNorm_Mlp(**config)
 
+    elif config.arch_name == "BayesianMlp":
+        arch = archs.BayesianMlp(**config)
+
 
     else:
         raise NotImplementedError(f"Arch {config.arch_name} not supported yet!")

--- a/surrogate/configs/case_bnn.py
+++ b/surrogate/configs/case_bnn.py
@@ -1,0 +1,62 @@
+import ml_collections
+
+
+def get_config():
+    config = ml_collections.ConfigDict()
+    config.mode = "train"
+
+    config.wandb = wandb = ml_collections.ConfigDict()
+    wandb.project = "MICRO_SURR_BNN"
+    wandb.name = "bnn_case"
+    wandb.tag = None
+
+    config.arch = arch = ml_collections.ConfigDict()
+    arch.arch_name = "BayesianMlp"
+    arch.hidden_dim = (128, 128, 128)
+    arch.out_dim = 9
+    arch.activation = "relu"
+    arch.prior_std = 1.0
+
+    config.training = training = ml_collections.ConfigDict()
+    training.max_epochs = 5000
+    training.batch_size = 4096
+
+    config.optim = optim = ml_collections.ConfigDict()
+    optim.optimizer = "Adam"
+    optim.beta1 = 0.9
+    optim.beta2 = 0.999
+    optim.eps = 1e-8
+    optim.learning_rate = 1e-3
+    optim.decay_rate = 0.9
+    optim.decay_steps = 3000
+    optim.grad_accum_steps = 0
+
+    config.weighting = weighting = ml_collections.ConfigDict()
+    weighting.scheme = "grad_norm"
+    weighting.init_weights = ml_collections.ConfigDict({"nll": 1., "kl": 1.})
+    weighting.momentum = 0.9
+    weighting.update_every_steps = 10000000000
+
+    config.logging = logging = ml_collections.ConfigDict()
+    logging.log_every_steps = 2000
+    logging.log_errors = True
+    logging.log_losses = True
+    logging.log_weights = True
+    logging.log_preds = False
+    logging.log_grads = False
+    logging.log_ntk = False
+
+    config.saving = saving = ml_collections.ConfigDict()
+    saving.save_epoch = 99
+    saving.num_keep_ckpts = 5
+
+    config.input_dim = 16
+    config.output_dim = arch.out_dim
+    config.use_train_test_split = True
+    config.use_train_val_test_split = True
+    config.use_l2reg = False
+    config.noise_std = 1.0
+
+    config.seed = 101
+
+    return config

--- a/surrogate/models.py
+++ b/surrogate/models.py
@@ -132,7 +132,46 @@ class MICRO_SURROGATE_L2(SURROGATE):
         #test_preds = (test_preds * self.output_std) + self.output_mean
         
         mse = jnp.mean((test_preds - y_scaled) ** 2)  # Mean Squared Error
-        
+
+        return mse
+
+
+class MICRO_SURROGATE_BNN(SURROGATE):
+    """Bayesian neural network surrogate using variational inference."""
+
+    def __init__(self, config, dataset_size, input_mean=None, input_std=None,
+                 output_mean=None, output_std=None,
+                 x_val=None, y_val=None):
+        super().__init__(config)
+        self.n_inputs = config.input_dim
+        self.n_outputs = config.output_dim
+        self.input_mean = input_mean
+        self.input_std = input_std
+        self.output_mean = output_mean
+        self.output_std = output_std
+        self.x_val = x_val
+        self.y_val = y_val
+        self.dataset_size = dataset_size
+        self.noise_std = getattr(config, "noise_std", 1.0)
+
+    def u_net(self, params, x, rng):
+        y, kl = self.state.apply_fn(params, x, rng)
+        return y, kl
+
+    def losses(self, params, batch_inputs, batch_targets, rng):
+        preds, kl = self.u_net(params, batch_inputs, rng)
+        mse = jnp.mean((preds - batch_targets) ** 2)
+        nll = mse / (2 * self.noise_std ** 2)
+        kl = kl / self.dataset_size
+        return {"nll": nll, "kl": kl}
+
+    @partial(jit, static_argnums=(0,))
+    def compute_validation_error(self, params):
+        test_inputs = (self.x_val - self.input_mean) / self.input_std
+        rng = jax.random.PRNGKey(0)
+        preds, _ = self.u_net(params, test_inputs, rng)
+        y_scaled = (self.y_val - self.output_mean) / self.output_std
+        mse = jnp.mean((preds - y_scaled) ** 2)
         return mse
 
 class MICRO_SURROGATE_Eval(BaseEvaluator):

--- a/surrogate/train_bnn.py
+++ b/surrogate/train_bnn.py
@@ -1,0 +1,125 @@
+import os
+import time
+import jax
+import jax.numpy as jnp
+from jax.tree_util import tree_map
+import ml_collections
+from absl import logging
+import wandb
+from NN_surrogate.logging import Logger
+from NN_surrogate.utils import save_checkpoint
+import orbax
+import models
+from utils import get_dataset
+import numpy as np
+
+
+def train_and_evaluate_bnn(config: ml_collections.ConfigDict, workdir: str):
+    dataset = get_dataset(config)
+    wandb_config = config.wandb
+    wandb.init(mode="online", project=wandb_config.project, name=wandb_config.name)
+
+    input_dim = config.input_dim
+    output_dim = config.output_dim
+
+    inputs = dataset[:, :input_dim]
+    targets = dataset[:, input_dim:]
+
+    input_mean = jnp.mean(inputs, axis=0)
+    input_std = jnp.std(inputs, axis=0) + 1e-8
+    target_mean = jnp.mean(targets, axis=0)
+    target_std = jnp.std(targets, axis=0) + 1e-8
+
+    inputs = (inputs - input_mean) / input_std
+    targets = (targets - target_mean) / target_std
+    dataset = jnp.concatenate([inputs, targets], axis=1)
+
+    norm_stats = {
+        "input_mean": input_mean,
+        "input_std": input_std,
+        "target_mean": target_mean,
+        "target_std": target_std,
+    }
+
+    logger = Logger()
+
+    dataset_size = dataset.shape[0]
+
+    if config.use_train_val_test_split:
+        test_data = np.genfromtxt("validation_data.csv", delimiter=",", skip_header=1)
+        test_inputs = test_data[:, :input_dim]
+        test_targets = test_data[:, input_dim:]
+        model = models.MICRO_SURROGATE_BNN(
+            config,
+            dataset_size,
+            input_mean=input_mean,
+            input_std=input_std,
+            output_mean=target_mean,
+            output_std=target_std,
+            x_val=test_inputs,
+            y_val=test_targets,
+        )
+    else:
+        model = models.MICRO_SURROGATE_BNN(config, dataset_size)
+
+    path = os.path.join(workdir, "ckpt", config.wandb.name)
+    abs_ckpt_path = os.path.abspath(path)
+    os.makedirs(abs_ckpt_path, exist_ok=True)
+
+    evaluator = models.MICRO_SURROGATE_Eval(config, model)
+
+    mgr_options = orbax.checkpoint.CheckpointManagerOptions(save_interval_steps=1, max_to_keep=3)
+    ckpt_mgr = orbax.checkpoint.CheckpointManager(
+        abs_ckpt_path,
+        orbax.checkpoint.Checkpointer(orbax.checkpoint.PyTreeCheckpointHandler()),
+        mgr_options,
+    )
+
+    start_time_total = time.time()
+    num_devices = jax.device_count()
+    num_samples = dataset.shape[0]
+    if num_samples % num_devices != 0:
+        new_size = (num_samples // num_devices) * num_devices
+        dataset = dataset[:new_size]
+    batch_size = config.training.batch_size
+    batch_size_per_device = batch_size // num_devices
+    if batch_size % num_devices != 0:
+        batch_size = batch_size_per_device * num_devices
+    num_batches = num_samples // batch_size
+
+    for epoch in range(config.training.max_epochs):
+        start_time = time.time()
+        key = jax.random.PRNGKey(epoch)
+        perm = jax.random.permutation(key, num_samples)
+        dataset_shuffled = dataset[perm]
+
+        for i in range(num_batches):
+            batch_key = jax.random.PRNGKey(epoch * num_batches + i)
+            batch_indices = jax.random.choice(batch_key, num_samples, (batch_size,), replace=False)
+            batch_data = dataset_shuffled[batch_indices]
+
+            batch_inputs = batch_data[:, :input_dim]
+            batch_targets = batch_data[:, input_dim:]
+
+            batch_inputs = jnp.reshape(batch_inputs, (num_devices, batch_size_per_device, -1))
+            batch_targets = jnp.reshape(batch_targets, (num_devices, batch_size_per_device, -1))
+            rngs = jax.random.split(batch_key, num_devices)
+
+            model.state = model.step(model.state, batch_inputs, batch_targets, rngs)
+
+            if jax.process_index() == 0 and (i % config.logging.log_every_steps == 0):
+                state = jax.device_get(jax.tree_map(lambda x: x[0], model.state))
+                log_dict = evaluator(state, batch_inputs, batch_targets, rngs[0])
+                wandb.log(log_dict, step=(epoch * num_batches + i))
+                end_time = time.time()
+                logger.log_iter(epoch, start_time, end_time, log_dict)
+
+        if epoch % config.saving.save_epoch == 0:
+            save_checkpoint(model.state, abs_ckpt_path, ckpt_mgr)
+
+    with open("time_summary.txt", "a") as f:
+        f.write("\n" + config.wandb.name + "--- %s seconds ---" % (time.time() - start_time_total))
+
+    jnp.savez(os.path.join(workdir, "normalization_stats.npz"), **norm_stats)
+
+    return model


### PR DESCRIPTION
## Summary
- introduce `BayesianDense` and `BayesianMlp` modules
- allow `BayesianMlp` in surrogate architecture loader
- implement `MICRO_SURROGATE_BNN` for variational Bayesian training
- add standalone Bayesian training routine
- provide example Bayesian configuration

## Testing
- `python -m py_compile surrogate/NN_surrogate/archs.py surrogate/NN_surrogate/models.py surrogate/models.py surrogate/train_bnn.py surrogate/configs/case_bnn.py`

------
https://chatgpt.com/codex/tasks/task_e_684056630c0c83339c562fe861a28123